### PR TITLE
Feature/test setup: Add Automated Testing Infrastructure For MDStress

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,3 +90,5 @@ if(MODULEFILES_PATH)
     # install it in the specified modulesfiles dir
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/mdstress-library DESTINATION ${MODULEFILES_PATH} PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
 endif(MODULEFILES_PATH)
+
+add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,33 @@ set_property(CACHE MDS_PRECISION PROPERTY STRINGS MDS_FLOAT MDS_DOUBLE MDS_LONG_
 list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_SOURCE_DIR}/contrib/eigen3")
 find_package(Eigen3 3.4 REQUIRED NO_MODULE)
 
+# Option to build tests
+option(BUILD_MDSTRESS_TESTS "Enable building of mdstress test executables" ON)
+
+# If tests are disabled, remove old test executables during configuration
+if(NOT BUILD_MDSTRESS_TESTS)
+    message(STATUS "Tests are disabled. Removing old test executables in build/test ...")
+
+    # compute path to build/test directory
+    set(TEST_DIR "${CMAKE_BINARY_DIR}/test")
+
+    # only remove if it exists
+    if(EXISTS ${TEST_DIR})
+        execute_process(
+            COMMAND ${CMAKE_COMMAND} -E remove_directory ${TEST_DIR}
+            RESULT_VARIABLE REMOVE_TEST_DIR_RESULT
+            OUTPUT_VARIABLE REMOVE_TEST_DIR_OUTPUT
+            ERROR_VARIABLE REMOVE_TEST_DIR_ERROR
+        )
+
+        if(NOT REMOVE_TEST_DIR_RESULT EQUAL 0)
+            message(WARNING "Failed to remove ${TEST_DIR}: ${REMOVE_TEST_DIR_ERROR}")
+        else()
+            message(STATUS "Removed old test executables at ${TEST_DIR}")
+        endif()
+    endif()
+endif()
+
 # set our cmake modules path for tclap
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
@@ -91,4 +118,6 @@ if(MODULEFILES_PATH)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/mdstress-library DESTINATION ${MODULEFILES_PATH} PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
 endif(MODULEFILES_PATH)
 
-add_subdirectory(test)
+if(BUILD_MDSTRESS_TESTS)
+    add_subdirectory(test)
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,7 +8,7 @@ foreach(TEST_SRC ${TEST_SOURCES})
     # Get the filename without path and extension
     get_filename_component(TEST_NAME ${TEST_SRC} NAME_WE)
 
-    add_executable(${TEST_NAME} ${TEST_SRC}
+    add_executable(${TEST_NAME} ${TEST_SRC})
    
     # Include headers
     target_include_directories(${TEST_NAME} PRIVATE

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 # test/CMakeLists.txt
 
-# Find all test soruce files that match test_*.cpp
+# Find all test source files that match test_*.cpp
 file(GLOB TEST_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/test_*.cpp")
 
 # Loop over each test file and create an executable
@@ -9,10 +9,10 @@ foreach(TEST_SRC ${TEST_SOURCES})
     get_filename_component(TEST_NAME ${TEST_SRC} NAME_WE)
 
     add_executable(${TEST_NAME} ${TEST_SRC})
-   
+
     # Include headers
     target_include_directories(${TEST_NAME} PRIVATE
-	${PROJECT_SOURCE_DIR}/include
+        ${PROJECT_SOURCE_DIR}/include
     )
 
     # Link against mdstress
@@ -20,5 +20,8 @@ foreach(TEST_SRC ${TEST_SOURCES})
 
     # Enable warnings
     target_compile_options(${TEST_NAME} PRIVATE -Wall -Wextra -Werror)
+
+    # Ensure assertions are active in tests
+    target_compile_options(${TEST_NAME} PRIVATE -UNDEBUG) # undefine NDEBUG
 endforeach()
-	    
+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,24 @@
+# test/CMakeLists.txt
+
+# Find all test soruce files that match test_*.cpp
+file(GLOB TEST_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/test_*.cpp")
+
+# Loop over each test file and create an executable
+foreach(TEST_SRC ${TEST_SOURCES})
+    # Get the filename without path and extension
+    get_filename_component(TEST_NAME ${TEST_SRC} NAME_WE)
+
+    add_executable(${TEST_NAME} ${TEST_SRC}
+   
+    # Include headers
+    target_include_directories(${TEST_NAME} PRIVATE
+	${PROJECT_SOURCE_DIR}/include
+    )
+
+    # Link against mdstress
+    target_link_libraries(${TEST_NAME} PRIVATE mdstress)
+
+    # Enable warnings
+    target_compile_options(${TEST_NAME} PRIVATE -Wall -Wextra -Werror)
+endforeach()
+	    

--- a/test/test_example.cpp
+++ b/test/test_example.cpp
@@ -4,9 +4,19 @@
 #include "mds_stressgrid.h"
 
 bool test_one(int input) {
-	assert(input == 1 && "test_one; Input should evaluate to 1");
+	
 
-	return True;
+	assert(input == 1 && "test_one; Input should evaluate to 1");
+	
+	if (input == 1) {
+		std::cout << "test_example/test_one has passed" << std::endl;
+	} else {
+		std::cout << "test_example/test_one has failed" << std::endl;
+		return false;
+	}
+
+
+	return true;
 }
 
 int main() {

--- a/test/test_example.cpp
+++ b/test/test_example.cpp
@@ -1,0 +1,19 @@
+#include <iostream>
+#include <cassert>
+
+#include "mds_stressgrid.h"
+
+bool test_one(int input) {
+	assert(input == 1 && "test_one; Input should evaluate to 1");
+
+	return True;
+}
+
+int main() {
+	test_one(1);
+	test_one(2);
+	return 0;
+}
+// Will probably have to compile like this (but this doesn't work):
+// g++ -Iinclude src/*.cpp test/test_mds_stressgrid.cpp -o test_mds_stressgrid
+


### PR DESCRIPTION
## Description:
This PR introduces a full testing system for the mdstress library:

- Adds a test/ directory for test_*.cpp files.

- Automatically discovers and compiles each test file into its own executable.

- Links all test executables against the mdstress library.

- Ensures assertions are active in tests regardless of build type.

- Adds a BUILD_MDSTRESS_TESTS CMake option to enable or disable building tests.

- Automatically cleans old test executables if tests are disabled.

- Preserves default behavior: tests are built automatically unless explicitly turned off.

This infrastructure makes it easy to add new tests and ensures reliable verification of library functionality.